### PR TITLE
v6.0.2 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+.pumafile
 
 node_modules
 .vscode

--- a/build/data-cache/data-cache.sh
+++ b/build/data-cache/data-cache.sh
@@ -6,7 +6,7 @@ BUCKET_NAME=$3
 DISTRIBUTION_ID=$4
 
 #install dep check
-curl -sLo ./dependency-check-$VERSION-release.zip https://dl.bintray.com/jeremy-long/owasp/dependency-check-$VERSION-release.zip
+curl -sLo ./dependency-check-$VERSION-release.zip https://github.com/jeremylong/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip
 unzip -q ./dependency-check-$VERSION-release.zip
 
 #version check

--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ps1
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ps1
@@ -155,6 +155,9 @@ try {
         Write-Host -Verbose "Path: $depCheckPath"
         Write-Host -Verbose "Arguments: $arguments"
 
+        # Set Java args
+        $env:JAVA_OPTS="-Xss8192k"
+
         # Run the scan
         $exitcode = (Start-Process -FilePath $depCheckPath -ArgumentList $arguments -PassThru -Wait -NoNewWindow).ExitCode
         Write-Host -Verbose "Dependency Check completed with exit code $exitcode."

--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ps1
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ps1
@@ -51,16 +51,17 @@ try {
     $additionalArguments = $additionalArguments.Trim();
     $localInstallPath = $localInstallPath.Trim();
 
-    #Create reports directory (if necessary)
-    if ($Env:BUILD_REPOSITORY_LOCALPATH -ne $suppressionPath){
+    #Set reports directory (if necessary)
+    if ($Env:BUILD_REPOSITORY_LOCALPATH -eq $reportsDirectory){
         $testDirectory = $Env:COMMON_TESTRESULTSDIRECTORY
         $reportsDirectory = "$testDirectory\dependency-check"
     }
+    Write-Host "Setting report directory to $reportsDirectory"
 
-    # Check if report directory does not exist
+    # Create report directory (if necessary)
     if(!(Test-Path -Path $reportsDirectory))
     {
-        Write-Host "Creating dependency check test results directory at $reportsDirectory"
+        Write-Host "Creating report directory at $reportsDirectory"
         New-Item $reportsDirectory -Type Directory
     }
 
@@ -117,13 +118,13 @@ try {
     $ProgressPreference = 'SilentlyContinue'
 
     # Set installation location
-    if ($Env:BUILD_REPOSITORY_LOCALPATH -ne $localInstallPath){
+    if ($Env:BUILD_REPOSITORY_LOCALPATH -eq $localInstallPath){
         #Get dependency check path
         $localInstallPath = "dependency-check"
         $localInstallPath = $localInstallPath | Resolve-Path
 
         if(Test-Path $binDirectory -PathType Container) {
-            Write-Host -Verbose "Downloading Dependency Check installer..."
+            Write-Host -Verbose "Downloading Dependency Check v$dependencyCheckVersion installer..."
             Invoke-WebRequest "https://github.com/jeremylong/DependencyCheck/releases/download/v$dependencyCheckVersion/dependency-check-$dependencyCheckVersion-release.zip" -OutFile "dependency-check-release.zip" 
             Expand-Archive -Path dependency-check-release.zip -DestinationPath . -Force
         }
@@ -146,7 +147,8 @@ try {
     $depCheck = "dependency-check.bat"    
     $depCheckScripts = "$localInstallPath/bin"
     $depCheckPath = $depCheckScripts | Resolve-Path | Join-Path -ChildPath "$depCheck"
-    
+    Write-Host -Verbose "Dependency Check installer set to $depCheckPath"
+
     #Default status to pass, change evaling the exit code below
     $failed = $false
 

--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ps1
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ps1
@@ -123,7 +123,7 @@ try {
         $localInstallPath = "dependency-check"
         $localInstallPath = $localInstallPath | Resolve-Path
 
-        if(Test-Path $binDirectory -PathType Container) {
+        if(Test-Path $localInstallPath -PathType Container) {
             Write-Host -Verbose "Downloading Dependency Check v$dependencyCheckVersion installer..."
             Invoke-WebRequest "https://github.com/jeremylong/DependencyCheck/releases/download/v$dependencyCheckVersion/dependency-check-$dependencyCheckVersion-release.zip" -OutFile "dependency-check-release.zip" 
             Expand-Archive -Path dependency-check-release.zip -DestinationPath . -Force

--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ps1
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ps1
@@ -32,11 +32,14 @@ try {
     $format = Get-VstsInput -Name 'format' -Require
     $failOnCVSS = Get-VstsInput -Name 'failOnCVSS' -Default ''
     $suppressionPath = Get-VstsInput -Name 'suppressionPath' -Default ''
+    $reportsDirectory = Get-VstsInput -Name 'reportsDirectory' -Default ''
     $enableExperimental = Get-VstsInput -Name 'enableExperimental' -Require -AsBool
     $enableRetired = Get-VstsInput -Name 'enableRetired' -Require -AsBool
     $enableVerbose = Get-VstsInput -Name 'enableVerbose' -Require -AsBool
-    $dataMirrorJson = Get-VstsInput -Name 'dataMirrorJson' -Default ''
-    $dataMirrorOdc = Get-VstsInput -Name 'dataMirrorOdc' -Default ''
+    $localInstallPath = Get-VstsInput -Name 'localInstallPath' -Default ''
+    $dependencyCheckVersion = Get-VstsInput -Name 'dependencyCheckVersion' -Default '6.0.2'
+    $dataMirror = Get-VstsInput -Name 'dataMirror' -Default ''
+    
     $additionalArguments = Get-VstsInput -Name 'additionalArguments' -Default ''
 
     #Trim the strings
@@ -44,11 +47,15 @@ try {
     $scanPath = $scanPath.Trim();
     $excludePath = $excludePath.Trim();
     $suppressionPath = $suppressionPath.Trim();
+    $reportsDirectory = $reportsDirectory.Trim();
     $additionalArguments = $additionalArguments.Trim();
+    $localInstallPath = $localInstallPath.Trim();
 
-    #Create reports directory
-    $testDirectory = $Env:COMMON_TESTRESULTSDIRECTORY
-    $reportsDirectory = "$testDirectory\dependency-check"
+    #Create reports directory (if necessary)
+    if ($Env:BUILD_REPOSITORY_LOCALPATH -ne $suppressionPath){
+        $testDirectory = $Env:COMMON_TESTRESULTSDIRECTORY
+        $reportsDirectory = "$testDirectory\dependency-check"
+    }
 
     # Check if report directory does not exist
     if(!(Test-Path -Path $reportsDirectory))
@@ -105,44 +112,39 @@ try {
         $arguments = $arguments + " " + $additionalArguments
     }
 
-    #Get dependency check path
-    $binDirectory = "dependency-check"
-    $binDirectory = $binDirectory | Resolve-Path
-
     #Set PS invoke web args
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $ProgressPreference = 'SilentlyContinue'
 
-    # Pull installer file
-    if(Test-Path $binDirectory -PathType Container) {
-        Write-Host -Verbose "Downloading Dependency Check installer..."
-        Invoke-WebRequest "https://dl.bintray.com/jeremy-long/owasp/dependency-check-5.3.2-release.zip" -OutFile "dependency-check-5.3.2-release.zip"
-        Expand-Archive -Path dependency-check-5.3.2-release.zip -DestinationPath . -Force
-    }
+    # Set installation location
+    if ($Env:BUILD_REPOSITORY_LOCALPATH -ne $localInstallPath){
+        #Get dependency check path
+        $localInstallPath = "dependency-check"
+        $localInstallPath = $localInstallPath | Resolve-Path
 
-    #Get dependency check data dir path
-    $dataDirectory = "dependency-check/data"
-    $dataDirectoryPath = $dataDirectory | Resolve-Path
-    
-    # Pull JSON cached file
-    if([string]::IsNullOrEmpty($dataMirrorJson) -eq $false ) {
-        if(Test-Path $dataDirectoryPath -PathType Container) {
-            Write-Host -Verbose "Downloading Dependency Check vulnerability JSON data mirror..."
-            Invoke-WebRequest $dataMirrorJson -OutFile "$dataDirectory/jsrepository.json"
+        if(Test-Path $binDirectory -PathType Container) {
+            Write-Host -Verbose "Downloading Dependency Check installer..."
+            Invoke-WebRequest "https://github.com/jeremylong/DependencyCheck/releases/download/v$dependencyCheckVersion/dependency-check-$dependencyCheckVersion-release.zip" -OutFile "dependency-check-release.zip" 
+            Expand-Archive -Path dependency-check-release.zip -DestinationPath . -Force
         }
     }
 
-    # Pull ODC cached file
-    if([string]::IsNullOrEmpty($dataMirrorOdc) -eq $false ) {
+    #Get dependency check data dir path
+    $dataDirectory = "$localInstallPath/data"
+    $dataDirectoryPath = $dataDirectory | Resolve-Path
+    
+    # Pull cached data archive
+    if([string]::IsNullOrEmpty($dataMirror) -eq $false ) {
         if(Test-Path $dataDirectoryPath -PathType Container) {
-            Write-Host -Verbose "Downloading Dependency Check vulnerability DB data mirror..."
-            Invoke-WebRequest $dataMirrorOdc -OutFile "$dataDirectory/odc.mv.db"
+            Write-Host -Verbose "Downloading Dependency Check data cache archive..."
+            Invoke-WebRequest $dataMirror -OutFile "$dataDirectory/data.zip"
+            Expand-Archive -Path "$dataDirectory/data.zip" -DestinationPath "$dataDirectory" -Force
         }
     }
 
     #Get dependency check script path
     $depCheck = "dependency-check.bat"    
-    $depCheckScripts = "dependency-check/bin"
+    $depCheckScripts = "$localInstallPath/bin"
     $depCheckPath = $depCheckScripts | Resolve-Path | Join-Path -ChildPath "$depCheck"
     
     #Default status to pass, change evaling the exit code below

--- a/src/Tasks/dependency-check-build-task/task.json
+++ b/src/Tasks/dependency-check-build-task/task.json
@@ -21,8 +21,7 @@
       "label": "Project Name",
       "helpMarkDown": "The name of the project being scanned.",
       "defaultValue": "",
-      "required": true,
-      "groupName": "Scan Configuration"
+      "required": true
     },
     {
       "name": "scanPath",
@@ -30,8 +29,7 @@
       "label": "Scan Path",
       "helpMarkDown": "The path to scan. Supports Ant style paths (e.g. 'directory/**/*.jar').",
       "defaultValue": "",
-      "required": true,
-      "groupName": "Scan Configuration"
+      "required": true
     },
     {
       "name": "excludePath",
@@ -39,8 +37,7 @@
       "label": "Exclude Path",
       "helpMarkDown": "The path patterns to exclude from the scan. Supports Ant style path patterns (e.g. /exclude/).",
       "defaultValue": "",
-      "required": false,
-      "groupName": "Scan Configuration"
+      "required": false
     },
     {
       "name": "format",
@@ -49,7 +46,6 @@
       "defaultValue": "HTML",
       "required": true,
       "helpMarkDown": "The output format to write to (XML, HTML, CSV, JSON, JUNIT, ALL). Multiple formats can be selected. The default is HTML.",
-      "groupName": "Scan Configuration",
       "properties": {
         "EditableOptions": "False",
         "MultiSelectFlatList": "True"
@@ -69,8 +65,7 @@
       "label": "CVSS Failure Threshold",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Threshold between 0 and 10 that will cause Dependency Check will return the exit code if a vulnerability with a CVSS score equal to or higher was identified.",
-      "groupName": "Scan Configuration"
+      "helpMarkDown": "Threshold between 0 and 10 that will cause Dependency Check will return the exit code if a vulnerability with a CVSS score equal to or higher was identified."
     },
     {
       "name": "suppressionPath",
@@ -78,8 +73,7 @@
       "label": "Suppression Paths",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "The file path to the suppression XML file used to suppress false positives. This can be specified more than once to utilize multiple suppression files. The argument can be a local file path, a URL to a suppression file, or even a reference to a file on the class path.",
-      "groupName": "Scan Configuration"
+      "helpMarkDown": "The file path to the suppression XML file used to suppress false positives. This can be specified more than once to utilize multiple suppression files. The argument can be a local file path, a URL to a suppression file, or even a reference to a file on the class path."
     },
     {
       "name": "reportsDirectory",
@@ -87,8 +81,7 @@
       "label": "Report Directory",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Report output directory. On-prem build agents can specify a local directory to override the default location. The default location is the $COMMON_TESTRESULTSDIRECTORY\\dependency-check directory.",
-      "groupName": "Scan Configuration"
+      "helpMarkDown": "Report output directory. On-prem build agents can specify a local directory to override the default location. The default location is the $COMMON_TESTRESULTSDIRECTORY\\dependency-check directory."
     },
     {
       "name": "enableExperimental",
@@ -96,8 +89,7 @@
       "label": "Experimental Analyzers",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Enable the experimental analyzers.",
-      "groupName": "Scan Configuration"
+      "helpMarkDown": "Enable the experimental analyzers."
     },
     {
       "name": "enableRetired",
@@ -105,8 +97,7 @@
       "label": "Retired Analyzers",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Enable the retired analyzers.",
-      "groupName": "Scan Configuration"
+      "helpMarkDown": "Enable the retired analyzers."
     },
     {
       "name": "enableVerbose",
@@ -114,8 +105,7 @@
       "label": "Verbose",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Enable verbose logging.",
-      "groupName": "Scan Configuration"
+      "helpMarkDown": "Enable verbose logging."
     },
     {
       "name": "additionalArguments",
@@ -123,8 +113,7 @@
       "label": "Additional Arguments",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Pass additional command line arguments to the Dependency Check command line interface.",
-      "groupName": "Scan Configuration"
+      "helpMarkDown": "Pass additional command line arguments to the Dependency Check command line interface."
     },
     {
       "name": "localInstallPath",
@@ -132,8 +121,7 @@
       "label": "Local Install Path",
       "helpMarkDown": "The local path to the `dependency-check` installation directory (on-prem build agents only). Setting this field will run Dependency Check locally instead of downloading the installer onto the build agent.",
       "defaultValue": "",
-      "required": false,
-      "groupName": "Installer Configuration"
+      "required": false
     },
     {
       "name": "dependencyCheckVersion",
@@ -141,8 +129,7 @@
       "label": "Installer Version",
       "helpMarkDown": "The Dependency Check version to download (cloud-hosted build agents only). Setting this field will download Dependency Check locally onto the build agent during execution.",
       "defaultValue": "6.0.2",
-      "required": false,
-      "groupName": "Installer Configuration"
+      "required": false
     },
     {
       "name": "dataMirror",
@@ -150,8 +137,7 @@
       "label": "Data Mirror Archive URL",
       "helpMarkDown": "The https path to the compressed Dependency Check data directory (containing the odc.mv.db and jsrepository.json files).",
       "defaultValue": "",
-      "required": false,
-      "groupName": "Installer Configuration"
+      "required": false
     }
   ],
   "instanceNameFormat": "Dependency Check",

--- a/src/Tasks/dependency-check-build-task/task.json
+++ b/src/Tasks/dependency-check-build-task/task.json
@@ -21,7 +21,8 @@
       "label": "Project Name",
       "helpMarkDown": "The name of the project being scanned.",
       "defaultValue": "",
-      "required": true
+      "required": true,
+      "groupName": "Scan Configuration"
     },
     {
       "name": "scanPath",
@@ -29,7 +30,8 @@
       "label": "Scan Path",
       "helpMarkDown": "The path to scan. Supports Ant style paths (e.g. 'directory/**/*.jar').",
       "defaultValue": "",
-      "required": true
+      "required": true,
+      "groupName": "Scan Configuration"
     },
     {
       "name": "excludePath",
@@ -37,7 +39,8 @@
       "label": "Exclude Path",
       "helpMarkDown": "The path patterns to exclude from the scan. Supports Ant style path patterns (e.g. /exclude/).",
       "defaultValue": "",
-      "required": false
+      "required": false,
+      "groupName": "Scan Configuration"
     },
     {
       "name": "format",
@@ -46,6 +49,7 @@
       "defaultValue": "HTML",
       "required": true,
       "helpMarkDown": "The output format to write to (XML, HTML, CSV, JSON, JUNIT, ALL). Multiple formats can be selected. The default is HTML.",
+      "groupName": "Scan Configuration",
       "properties": {
         "EditableOptions": "False",
         "MultiSelectFlatList": "True"
@@ -65,7 +69,8 @@
       "label": "CVSS Failure Threshold",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Threshold between 0 and 10 that will cause Dependency Check will return the exit code if a vulnerability with a CVSS score equal to or higher was identified."
+      "helpMarkDown": "Threshold between 0 and 10 that will cause Dependency Check will return the exit code if a vulnerability with a CVSS score equal to or higher was identified.",
+      "groupName": "Scan Configuration"
     },
     {
       "name": "suppressionPath",
@@ -73,7 +78,17 @@
       "label": "Suppression Paths",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "The file path to the suppression XML file used to suppress false positives. This can be specified more than once to utilize multiple suppression files. The argument can be a local file path, a URL to a suppression file, or even a reference to a file on the class path."
+      "helpMarkDown": "The file path to the suppression XML file used to suppress false positives. This can be specified more than once to utilize multiple suppression files. The argument can be a local file path, a URL to a suppression file, or even a reference to a file on the class path.",
+      "groupName": "Scan Configuration"
+    },
+    {
+      "name": "reportsDirectory",
+      "type": "filePath",
+      "label": "Report Directory",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Report output directory. On-prem build agents can specify a local directory to override the default location. The default location is the $COMMON_TESTRESULTSDIRECTORY\\dependency-check directory.",
+      "groupName": "Scan Configuration"
     },
     {
       "name": "enableExperimental",
@@ -81,7 +96,8 @@
       "label": "Experimental Analyzers",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Enable the experimental analyzers."
+      "helpMarkDown": "Enable the experimental analyzers.",
+      "groupName": "Scan Configuration"
     },
     {
       "name": "enableRetired",
@@ -89,7 +105,8 @@
       "label": "Retired Analyzers",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Enable the retired analyzers."
+      "helpMarkDown": "Enable the retired analyzers.",
+      "groupName": "Scan Configuration"
     },
     {
       "name": "enableVerbose",
@@ -97,23 +114,8 @@
       "label": "Verbose",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Enable verbose logging."
-    },
-    {
-      "name": "dataMirrorOdc",
-      "type": "string",
-      "label": "ODC Database File Mirror (odc.mv.db) URL",
-      "helpMarkDown": "The https path to the cached Dependency Check database file (odc.mv.db).",
-      "defaultValue": "",
-      "required": false
-    },
-    {
-      "name": "dataMirrorJson",
-      "type": "string",
-      "label": "JSON Repository File Mirror (jsrepository.json) URL",
-      "helpMarkDown": "The https path to the cached Dependency Check JSON repository file (jsrepository.json).",
-      "defaultValue": "",
-      "required": false
+      "helpMarkDown": "Enable verbose logging.",
+      "groupName": "Scan Configuration"
     },
     {
       "name": "additionalArguments",
@@ -121,7 +123,35 @@
       "label": "Additional Arguments",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Pass additional command line arguments to the Dependency Check command line interface."
+      "helpMarkDown": "Pass additional command line arguments to the Dependency Check command line interface.",
+      "groupName": "Scan Configuration"
+    },
+    {
+      "name": "localInstallPath",
+      "type": "filePath",
+      "label": "Local Install Path",
+      "helpMarkDown": "The local path to the `dependency-check` installation directory (on-prem build agents only). Setting this field will run Dependency Check locally instead of downloading the installer onto the build agent.",
+      "defaultValue": "",
+      "required": false,
+      "groupName": "Installer Configuration"
+    },
+    {
+      "name": "dependencyCheckVersion",
+      "type": "string",
+      "label": "Installer Version",
+      "helpMarkDown": "The Dependency Check version to download (cloud-hosted build agents only). Setting this field will download Dependency Check locally onto the build agent during execution.",
+      "defaultValue": "6.0.2",
+      "required": false,
+      "groupName": "Installer Configuration"
+    },
+    {
+      "name": "dataMirror",
+      "type": "string",
+      "label": "Data Mirror Archive URL",
+      "helpMarkDown": "The https path to the compressed Dependency Check data directory (containing the odc.mv.db and jsrepository.json files).",
+      "defaultValue": "",
+      "required": false,
+      "groupName": "Installer Configuration"
     }
   ],
   "instanceNameFormat": "Dependency Check",


### PR DESCRIPTION
Hotfix release addresses several issues related to downloading the dependency check installer on the fly. Also includes additional configuration options for supporting on-prem build agents.

- #47: Convert installer download from bintry to github release endpoint for the auto-install on cloud-hosted agents.

- #45: Option to specify a local installer location and override the auto-install download on cloud-hosted agents.

- #42: Option to override the default report output location.

- #49: Option to specify the dependency check version for the auto-install download on cloud-hosted agents.