### PR TITLE
Add reportFilename parameter and documentation

### DIFF
--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
@@ -26,6 +26,7 @@ async function run() {
         let failOnCVSS: string | undefined = tl.getInput('failOnCVSS');
         let suppressionPath: string | undefined = tl.getPathInput('suppressionPath');
         let reportsDirectory: string | undefined = tl.getPathInput('reportsDirectory');
+        let reportFilename: string | undefined = tl.getPathInput('reportFilename');
         let enableExperimental: boolean | undefined = tl.getBoolInput('enableExperimental', true);
         let enableRetired: boolean | undefined = tl.getBoolInput('enableRetired', true);
         let enableVerbose: boolean | undefined = tl.getBoolInput('enableVerbose', true);
@@ -41,6 +42,7 @@ async function run() {
         excludePath = excludePath?.trim();
         suppressionPath = suppressionPath?.trim();
         reportsDirectory = reportsDirectory?.trim();
+        reportFilename = reportFilename?.trim();
         additionalArguments = additionalArguments?.trim();
         localInstallPath = localInstallPath?.trim();
 
@@ -61,8 +63,14 @@ async function run() {
             tl.mkdirP(reportsDirectory!);
         }
 
+        // Set output folder (and filename if supplied)
+        let outField: string = reportsDirectory;
+        if (reportFilename && format?.split(',')?.length === 1 && format != "ALL") {
+            outField = tl.resolve(reportsDirectory, reportFilename);
+        }
+
         // Default args
-        let args = `--project "${projectName}" --scan "${scanPath}" --out "${reportsDirectory}"`;
+        let args = `--project "${projectName}" --scan "${scanPath}" --out "${outField}"`;
 
         // Exclude switch
         if (excludePath != sourcesDirectory)

--- a/src/Tasks/dependency-check-build-task/task.json
+++ b/src/Tasks/dependency-check-build-task/task.json
@@ -82,6 +82,14 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Report output directory. On-prem build agents can specify a local directory to override the default location. The default location is the $COMMON_TESTRESULTSDIRECTORY\\dependency-check directory."
+    },    
+    {
+      "name": "reportFilename",
+      "type": "string",
+      "label": "Report Filename",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Report output filename. Will set the report output name in 'reportsDirectory' to specified filename. Will not work if format is ALL, or multiple formats are supplied to the 'format' parameter. Filename must have an extension or dependency-check will assume it is a path."
     },
     {
       "name": "enableExperimental",


### PR DESCRIPTION
Allow the the pipeline to control the filename output instead of always using 'dependency-check-report.extension'