### PR TITLE
Multiple Bugfixes, some improvements

### DIFF
--- a/build/Build-Extension.ps1
+++ b/build/Build-Extension.ps1
@@ -1,0 +1,271 @@
+
+<#PSScriptInfo
+
+.VERSION 1.0.0
+
+.GUID 6312d879-4b8c-4d88-aa39-bf245069148e
+
+.AUTHOR Markus Szumovski
+
+.COMPANYNAME -
+
+.COPYRIGHT 2021
+
+.TAGS
+
+.LICENSEURI
+
+.PROJECTURI
+
+.ICONURI
+
+.EXTERNALMODULEDEPENDENCIES 
+
+.REQUIREDSCRIPTS
+
+.EXTERNALSCRIPTDEPENDENCIES
+
+.RELEASENOTES
+V 1.0.0: Initial version
+
+.PRIVATEDATA
+
+#> 
+
+<# 
+
+.SYNOPSIS
+    Will build the extension.
+.DESCRIPTION 
+    Will build the extension.
+.PARAMETER ExtensionRepositoryRoot
+    The path to the extension repository root from where to build the extension from.
+    Will default to parent directory of script if no path or $null was provided.
+.PARAMETER BuildEnvironment
+    Set to "Release" for production environment or set to anything else (for example "Development") for development environment.
+    If nothing was provided the Release environment will be built.
+.PARAMETER BuildVersion
+    If provided will set the version number.
+    If not provided the version number will not be changed.
+.PARAMETER NoPackaging
+    If the switch was provided, the built extension will not be packaged up into a vsix file.
+.OUTPUTS
+    Building and packaging progress
+  
+.EXAMPLE
+  Build-Extension -BuildVersion "6.1.0.1" -BuildEnvironment "Release" 
+#> 
+[CmdletBinding(SupportsShouldProcess=$True)]
+Param
+(
+    [Parameter(Position=0)]
+    [string] $ExtensionRepositoryRoot = $null,
+    [Parameter(Position=1)]
+    [string] $BuildEnvironment = "Release",
+    [Parameter(Position=2)]
+    [string] $BuildVersion = $null,
+    [Parameter(Position=3)]
+    [switch] $NoPackaging
+
+)
+
+### --- START --- functions
+### --- END --- functions
+
+### --- START --- main script ###
+try {
+    Write-Host "--- Build extension script started ---`r`n`r`n" -ForegroundColor DarkGreen
+
+    if([string]::IsNullOrWhiteSpace($ExtensionRepositoryRoot)) {
+        Write-Host "No extension repository root provided, determining path now..."
+        $ExtensionRepositoryRoot = Split-Path -Path (Split-Path -Path $MyInvocation.MyCommand.Path -Parent -ErrorAction Stop) -Parent -ErrorAction Stop
+        Write-Host ""
+    }
+    else {
+        $ExtensionRepositoryRoot = Resolve-Path -Path $ExtensionRepositoryRoot -ErrorAction Ignore
+    }
+
+    if([string]::IsNullOrWhiteSpace($BuildEnvironment)) {
+        $BuildEnvironment = "Release"
+    }
+
+    # Set build env vars
+    if ($BuildEnvironment -eq "Release") {
+        $TaskId = "47EA1F4A-57BA-414A-B12E-C44F42765E72"
+        $TaskName = "dependency-check-build-task"
+        $VssExtensionName = "vss-extension.prod.json"
+    }
+    else {
+        $TaskId = "04450B31-9F11-415A-B37A-514D69EF69A1"
+        $TaskName = "dependency-check-build-task-dev"
+        $VssExtensionName = "vss-extension.dev.json"
+    }
+
+    $ExtensionRepositoryRootExists = Test-Path -Path $ExtensionRepositoryRoot -ErrorAction Ignore
+
+    if($ExtensionRepositoryRootExists) {
+        $TaskFolderPath = Join-Path -Path $ExtensionRepositoryRoot -ChildPath "src\Tasks\dependency-check-build-task" -ErrorAction Stop
+
+        $TaskDefPath = Join-Path -Path $TaskFolderPath -ChildPath "task.json" -ErrorAction Stop
+        $TaskDefExists = Test-Path -Path $TaskDefPath -ErrorAction Ignore
+
+        $VssExtensionPath = Join-Path -Path $ExtensionRepositoryRoot -ChildPath $VssExtensionName -ErrorAction Stop
+        $VssExtensionExists = Test-Path -Path $VssExtensionPath -ErrorAction Ignore
+    }
+    else {
+        $TaskFolderPath = $null
+        $TaskDefPath = $null
+        $TaskDefExists = $false
+        $VssExtensionPath = $null
+        $VssExtensionExists = $false
+    }
+
+    #Parse version vars
+    $VerPatchRevision = $null
+    if(![string]::IsNullOrWhiteSpace($BuildVersion)) {
+        $VerMajor,$VerMinor,$VerPatch,$VerRevision = $BuildVersion.Split('.')
+        if($null -eq $VerMajor) {
+            $VerMajor = 0
+        }
+        if($null -eq $VerMinor) {
+            $VerMinor = 0
+        }
+        if($null -eq $VerPatch) {
+            $VerPatch = 0
+        }
+        if($null -eq $VerRevision) {
+            $VerRevision = 0
+        }
+        $VerPatchRevision = [string]::Format("{0}{1}", $VerPatch, $VerRevision.PadLeft(3, '0'))
+        $BuildVersion = "$VerMajor.$VerMinor.$VerPatch.$VerRevision"
+        $BuildTaskVersion = "$VerMajor.$VerMinor.$VerPatchRevision"
+    }
+
+
+    Write-Host "------------------------------"
+
+    Write-Host "Extension repository root: ""$ExtensionRepositoryRoot"" (" -NoNewline
+    if($ExtensionRepositoryRootExists) {
+        Write-Host "exists" -ForegroundColor Green -NoNewline
+    }
+    else {
+        Write-Host "missing" -ForegroundColor Red -NoNewline
+    }
+    Write-Host ")"
+
+    Write-Host "Task definition JSON: ""$TaskDefPath"" (" -NoNewline
+    if($TaskDefExists) {
+        Write-Host "exists" -ForegroundColor Green -NoNewline
+    }
+    else {
+        Write-Host "missing" -ForegroundColor Red -NoNewline
+    }
+    Write-Host ")"
+
+    Write-Host "VSS extension JSON: ""$VssExtensionPath"" (" -NoNewline
+    if($VssExtensionExists) {
+        Write-Host "exists" -ForegroundColor Green -NoNewline
+    }
+    else {
+        Write-Host "missing" -ForegroundColor Red -NoNewline
+    }
+    Write-Host ")"
+
+    Write-Host "Build environment: $BuildEnvironment"
+    if([string]::IsNullOrWhiteSpace($BuildVersion)) {
+        Write-Host "Build version: <none defined>"
+    }
+    else {
+        Write-Host "Build version: $BuildVersion"
+        Write-Host "Build-Task version: $BuildTaskVersion"
+    }
+
+    Write-Host "Task-Id: $TaskId"
+    Write-Host "Task-Name: $TaskName"
+    Write-Host "VSS extension JSON: $VssExtensionName"
+
+    Write-Host "------------------------------`r`n"
+
+    if($ExtensionRepositoryRootExists) {
+        if($TaskDefExists) {
+
+            Write-Host "Reading task.json..."
+            $TaskJson = Get-Content -Path $TaskDefPath -Raw | ConvertFrom-Json
+
+            Write-Host "Setting task definition id and name..."
+            $TaskJson.id = $TaskId
+            $TaskJson.name = $TaskName
+
+            if([string]::IsNullOrWhiteSpace($BuildVersion)) {
+                Write-Host "(Skipping setting of task definition version since no version was provided)"
+            }
+            else {
+                Write-Host "Setting task definition version..."
+                $TaskJson.version.Major = $VerMajor
+                $TaskJson.version.Minor = $VerMinor
+                $TaskJson.version.Patch = $VerPatchRevision
+            }
+
+            Write-Host "Saving new task definition..."
+            $TaskJson | ConvertTo-Json -Depth 100 | Set-Content -Path $TaskDefPath
+
+            if([string]::IsNullOrWhiteSpace($BuildVersion)) {
+                Write-Host "(Skipping setting of extension version since no version was provided)"
+            }
+            else {
+                Write-Host "Reading ""$VssExtensionName""..."
+                $VssExtensionJson = Get-Content -Path $VssExtensionPath -Raw | ConvertFrom-Json
+
+                Write-Host "Setting version"
+                $VssExtensionJson.version = $BuildVersion
+
+                Write-Host "Saving new extension definition..."
+                $VssExtensionJson | ConvertTo-Json -Depth 100 | Set-Content $VssExtensionPath
+            }
+
+            Write-Host "`r`nBuilding task..."
+            Write-Host "------------------------------"
+            Push-Location
+            Set-Location -Path $TaskFolderPath
+            &"npm" install
+            &"npm" run build
+            Pop-Location
+            Write-Host "------------------------------"
+            Write-Host "`r`nBuilding extension..."
+            Write-Host "------------------------------"
+            &"npm" install
+            &"npm" run build
+            Write-Host "------------------------------"
+
+            if(!$NoPackaging.IsPresent) {
+                Write-Host "`r`nPackaging..."
+                if($BuildEnvironment -eq "Release") {
+                    &"npm" run package-prod
+                }
+                else {
+                    &"npm" run package-dev
+                }
+    
+                Write-Host "`r`nBuilding and packaging extension..." -NoNewline    
+            }
+            else {
+                Write-Host "`r`nBuilding extension..." -NoNewline    
+            }
+
+            Write-Host "DONE" -ForegroundColor Green
+        }
+        else {
+            Write-Warning "Task.json not found, cannot continue"
+        }
+    }
+    else {
+        Write-Warning "Extension repository root not found, cannot continue"
+    }
+}
+finally {
+    Write-Host "`r`n`r`n--- Build extension script ended ---" -ForegroundColor DarkGreen
+}
+
+#and we're at the end
+
+### --- END --- main script ###

--- a/build/README.md
+++ b/build/README.md
@@ -4,7 +4,17 @@ Let's start with this: We can automate this with a pipeline later and eliminate 
 
 Start by making your changes to the extension. When you are ready to test and release, use the steps below.
 
-## Build Task Version
+## PowerShell Core building
+
+The simplest way to create a new vsix package for development or production environment is to use the ./build/Build-Extension.ps1 PowerShell Core script (PowerShell Core needs to be installed for this script to work).
+
+Just call it via `pwsh ./build/Build-Extension.ps1 -BuildVersion "6.1.0.0" -BuildEnvironment "Release"` and replace the -BuildVersion string with the new version number and use "Release" as BuildEnvironment for production and "Development" as BuildEnvironment for development.
+
+After the call the new VSIX file should have been created in the repository root directory.
+
+## Manual building
+
+### Build Task Version
 
 To release a new version, start by opening the *src/Tasks/dependency-check-build-task/task.json* file. Bump the version number. Keep the major and minor versions in sync with the core Dependency Check CLI. The patch release has to be updated every time you want to change the extension. Even in development. Think of it like a build number. Azure won't update the build task during an update if this value is the same as the currently installed build task in a pipeline. So, we put some 0's on th end to tell us what version of Dependency Check we are using, as well as the build id of the extension itself. Example 5.1.1 = 5.1.\[1000-1999\].
 
@@ -16,7 +26,7 @@ To release a new version, start by opening the *src/Tasks/dependency-check-build
 },
 ```
 
-## Building for DEV
+### Building for DEV
 
 Open the **package.json** file and modify the package line:
 
@@ -58,7 +68,7 @@ dependency-check.azuredevops-dev-5.2.0.000.vsix
 
 Upload the the marketplace manually (for now until the release pipeline works)
 
-## Build for PROD
+### Build for PROD
 
 Open the **package.json** file and update the package command to the prod value:
 

--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
@@ -27,7 +27,6 @@ async function run() {
         let suppressionPath: string | undefined = tl.getPathInput('suppressionPath');
         let reportsDirectory: string | undefined = tl.getPathInput('reportsDirectory');
 		let warnOnCVSSViolation: boolean | undefined = tl.getBoolInput('warnOnCVSSViolation', true);
-		let warnOnToolError: boolean | undefined = tl.getBoolInput('warnOnToolError', true);
         let enableExperimental: boolean | undefined = tl.getBoolInput('enableExperimental', true);
         let enableRetired: boolean | undefined = tl.getBoolInput('enableRetired', true);
         let enableVerbose: boolean | undefined = tl.getBoolInput('enableVerbose', true);
@@ -225,13 +224,7 @@ async function run() {
 			}
             else {
                 message = "Dependency Check exited with an error code (exit code: " + exitCode + ")."
-
-                if(warnOnToolError) {
-                    result = tl.TaskResult.SucceededWithIssues
-                }
-                else {
-                    result = tl.TaskResult.Failed
-                }
+                result = tl.TaskResult.Failed
             }
         }
 

--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
@@ -147,7 +147,7 @@ async function run() {
         await tl.tool(depCheckPath).arg('--version').exec();
 
         // Run the scan
-        let exitCode = await tl.tool(depCheckPath).line(args).exec({ failOnStdErr: false, ignoreReturnCode: false });
+        let exitCode = await tl.tool(depCheckPath).line(args).exec({ failOnStdErr: false, ignoreReturnCode: true });
         console.log(`Dependency Check completed with exit code ${exitCode}.`);
         console.log('Dependency Check reports:');
         console.log(tl.findMatch(reportsDirectory, '**/*.*'));

--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
@@ -26,7 +26,7 @@ async function run() {
         let failOnCVSS: string | undefined = tl.getInput('failOnCVSS');
         let suppressionPath: string | undefined = tl.getPathInput('suppressionPath');
         let reportsDirectory: string | undefined = tl.getPathInput('reportsDirectory');
-		let warnOnCVSSViolation: boolean | undefined = tl.getBoolInput('warnOnCVSSViolation', true);
+        let warnOnCVSSViolation: boolean | undefined = tl.getBoolInput('warnOnCVSSViolation', true);
         let enableExperimental: boolean | undefined = tl.getBoolInput('enableExperimental', true);
         let enableRetired: boolean | undefined = tl.getBoolInput('enableRetired', true);
         let enableVerbose: boolean | undefined = tl.getBoolInput('enableVerbose', true);
@@ -35,7 +35,7 @@ async function run() {
         let dataMirror: string | undefined = tl.getInput('dataMirror');
         let customRepo: string | undefined = tl.getInput('customRepo');
         let additionalArguments: string | undefined = tl.getInput('additionalArguments');
-		let hasLocalInstallation = true;
+        let hasLocalInstallation = true;
 
         // Trim the strings
         projectName = projectName?.trim()
@@ -102,7 +102,7 @@ async function run() {
 
         // Set installation location
         if (localInstallPath == sourcesDirectory) {
-			hasLocalInstallation = false;
+            hasLocalInstallation = false;
             localInstallPath = tl.resolve('./dependency-check');
 
             tl.checkPath(localInstallPath, 'Dependency Check installer');
@@ -149,38 +149,38 @@ async function run() {
         // Version smoke test
         await tl.tool(depCheckPath).arg('--version').exec();
 
-		if(!hasLocalInstallation) {
-			// Remove lock files from potential previous canceled run if no local/centralized installation of tool is used.
-			// We need this because due to a bug the dependency check tool is currently leaving .lock files around if you cancel at the wrong moment.
-			// Since a per-agent installation shouldn't be able to run two scans parallel, we can savely remove all lock files still lying around.
-			console.log('Searching for left over lock files...');
-			let lockFiles = tl.findMatch(localInstallPath, '*.lock', null, { matchBase: true });
-			if(lockFiles.length > 0) {
-				console.log('found ' + lockFiles.length + ' left over lock files, removing them now...');
-				lockFiles.forEach(lockfile => {
-					let fullLockFilePath = tl.resolve(lockfile);
-					try {
-						if(tl.exist(fullLockFilePath)) {
-							console.log('removing lock file "' + fullLockFilePath + '"...');
-							tl.rmRF(fullLockFilePath);
-						}
-						else {
-							console.log('found lock file "' + fullLockFilePath + '" doesn\'t exist, that was unexpected');
-						}
-					}
-					catch (err) {
-						console.log('could not delete lock file "' + fullLockFilePath + '"!');
-						console.error(err);
-					}
-				});
-			}
-			else {
-				console.log('found no left over lock files, continuing...');
-			}
-		}
+        if(!hasLocalInstallation) {
+            // Remove lock files from potential previous canceled run if no local/centralized installation of tool is used.
+            // We need this because due to a bug the dependency check tool is currently leaving .lock files around if you cancel at the wrong moment.
+            // Since a per-agent installation shouldn't be able to run two scans parallel, we can savely remove all lock files still lying around.
+            console.log('Searching for left over lock files...');
+            let lockFiles = tl.findMatch(localInstallPath, '*.lock', null, { matchBase: true });
+            if(lockFiles.length > 0) {
+                console.log('found ' + lockFiles.length + ' left over lock files, removing them now...');
+                lockFiles.forEach(lockfile => {
+                    let fullLockFilePath = tl.resolve(lockfile);
+                    try {
+                        if(tl.exist(fullLockFilePath)) {
+                            console.log('removing lock file "' + fullLockFilePath + '"...');
+                            tl.rmRF(fullLockFilePath);
+                        }
+                        else {
+                            console.log('found lock file "' + fullLockFilePath + '" doesn\'t exist, that was unexpected');
+                        }
+                    }
+                    catch (err) {
+                        console.log('could not delete lock file "' + fullLockFilePath + '"!');
+                        console.error(err);
+                    }
+                });
+            }
+            else {
+                console.log('found no left over lock files, continuing...');
+            }
+        }
 
         // Run the scan
-		let exitCode = await tl.tool(depCheckPath).line(args).exec({ failOnStdErr: false, ignoreReturnCode: true });
+        let exitCode = await tl.tool(depCheckPath).line(args).exec({ failOnStdErr: false, ignoreReturnCode: true });
         console.log(`Dependency Check completed with exit code ${exitCode}.`);
         console.log('Dependency Check reports:');
         console.log(tl.findMatch(reportsDirectory, '**/*.*'));
@@ -212,8 +212,8 @@ async function run() {
         let message = "Dependency Check succeeded"
         let result = tl.TaskResult.Succeeded
         if (failed) {
-			if(isViolation) {
-				message = "CVSS threshold violation.";
+            if(isViolation) {
+                message = "CVSS threshold violation.";
 
                 if(warnOnCVSSViolation) {
                     result = tl.TaskResult.SucceededWithIssues
@@ -221,7 +221,7 @@ async function run() {
                 else {
                     result = tl.TaskResult.Failed
                 }
-			}
+            }
             else {
                 message = "Dependency Check exited with an error code (exit code: " + exitCode + ")."
                 result = tl.TaskResult.Failed
@@ -285,29 +285,29 @@ async function getZipUrl(version: string): Promise<void> {
 async function unzipFromUrl(zipUrl: string, unzipLocation: string): Promise<void> {
     let fileName = path.basename(url.parse(zipUrl).pathname);
     let zipLocation = tl.resolve(fileName)
-	let tmpError = null;
-	let response = null;
-	let downloadErrorRetries = 5;
-	
-	do {
-		tmpError = null;
-		try {
-			await console.log('Downloading ZIP from "' + zipUrl + '"...');
-			response = await client.get(zipUrl);
-			await logDebug('done downloading');
-		}
-		catch(error) {
-			tmpError = error;
-			downloadErrorRetries--;
-			await console.error('Error trying to download ZIP (' + (downloadErrorRetries+1) + ' tries left)');
-			await console.error(error);
-		}
-	}
-	while(tmpError !== null && downloadErrorRetries >= 0);
-	
-	if(tmpError !== null) {
-		throw tmpError;
-	}
+    let tmpError = null;
+    let response = null;
+    let downloadErrorRetries = 5;
+    
+    do {
+        tmpError = null;
+        try {
+            await console.log('Downloading ZIP from "' + zipUrl + '"...');
+            response = await client.get(zipUrl);
+            await logDebug('done downloading');
+        }
+        catch(error) {
+            tmpError = error;
+            downloadErrorRetries--;
+            await console.error('Error trying to download ZIP (' + (downloadErrorRetries+1) + ' tries left)');
+            await console.error(error);
+        }
+    }
+    while(tmpError !== null && downloadErrorRetries >= 0);
+    
+    if(tmpError !== null) {
+        throw tmpError;
+    }
 
     await logDebug('Download was successful, saving downloaded ZIP file...');
 

--- a/src/Tasks/dependency-check-build-task/package.json
+++ b/src/Tasks/dependency-check-build-task/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "azure-pipelines-task-lib": "^3.0.6-preview.1",
     "decompress-zip": "^0.3.3",
+    "is-core-module": "^2.4.0",
+    "resolve": "^1.20.0",
     "typed-rest-client": "^1.8.1"
   },
   "devDependencies": {

--- a/src/Tasks/dependency-check-build-task/task.json
+++ b/src/Tasks/dependency-check-build-task/task.json
@@ -84,6 +84,22 @@
       "helpMarkDown": "Report output directory. On-prem build agents can specify a local directory to override the default location. The default location is the $COMMON_TESTRESULTSDIRECTORY\\dependency-check directory."
     },
     {
+      "name": "warnOnCVSSViolation",
+      "type": "boolean",
+      "label": "Only warnings for found violations",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "Will only warn for found violations above the CVSS failure threshold instead of throwing errors, and the build step will succeed-with-issues. This ensures that even if violations were found, the pipeline will not be stopped."
+    },
+    {
+      "name": "warnOnToolError",
+      "type": "boolean",
+      "label": "Only warnings for errors (with dependency check tool)",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "Will only warn for errors with dependency check tool and the step will succeed-with-issues. This ensures that even if errors with the dependency check tool arise, the pipeline will not be stopped."
+    },
+    {
       "name": "enableExperimental",
       "type": "boolean",
       "label": "Experimental Analyzers",

--- a/src/Tasks/dependency-check-build-task/task.json
+++ b/src/Tasks/dependency-check-build-task/task.json
@@ -86,10 +86,10 @@
     {
       "name": "warnOnCVSSViolation",
       "type": "boolean",
-      "label": "Only warnings for found violations",
+      "label": "Only warn for found violations",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Will only warn for found violations above the CVSS failure threshold instead of throwing errors, and the build step will succeed-with-issues. This ensures that even if violations were found, the pipeline will not be stopped."
+      "helpMarkDown": "Will only warn for found violations above the CVSS failure threshold instead of throwing an error. This build step will then succeed with issues instead of failing."
     },
     {
       "name": "enableExperimental",

--- a/src/Tasks/dependency-check-build-task/task.json
+++ b/src/Tasks/dependency-check-build-task/task.json
@@ -92,14 +92,6 @@
       "helpMarkDown": "Will only warn for found violations above the CVSS failure threshold instead of throwing errors, and the build step will succeed-with-issues. This ensures that even if violations were found, the pipeline will not be stopped."
     },
     {
-      "name": "warnOnToolError",
-      "type": "boolean",
-      "label": "Only warnings for errors (with dependency check tool)",
-      "defaultValue": "false",
-      "required": false,
-      "helpMarkDown": "Will only warn for errors with dependency check tool and the step will succeed-with-issues. This ensures that even if errors with the dependency check tool arise, the pipeline will not be stopped."
-    },
-    {
       "name": "enableExperimental",
       "type": "boolean",
       "label": "Experimental Analyzers",


### PR DESCRIPTION
### Bugfixes
* Add report attachments if vulnerability was detected (not just wenn no vulnerability was detected). Seems this was the idea from the beginning, but extension was prevented from doing so because tool exit-code wasn't ignored on call.
* Only print out/report end-result once (as warning or error) instead of twice.
* Added a few debug messages and changed debug messages output so they'll only be printed out if system.debug=true (generic pipeline debug variable)
* Remove left over locks from previous dependency check tool run as long as no custom (and possibly centralized) dependency check tool is used. This is needed because if the build is canceled during the dependency check tool update/run some lock files might be left over due to the JAVA runtime being canceled before the dependency check tool has realized it has been stopped. This would lead to the build being stuck/hung at the dependency check tool build step on the next run since the lock files would persist. The removal of those lock files will not be done for dependency check tools with a custom path since those might be used centralized and may actually need those lock files so not to get into conflict with multiple agents on the same machine.
* Requiring specific node module versions for these packages because older versions would have unallowed characters in their extension manifest mime-type: 
  * is-core-module>=2.4.0
  * resolve>=1.20.0

### Additional functionality/Improvements
* Will retry downloading dependency check ZIP up to 5 times if it fails (due to shakey network connection for exmaple, badly needed by ourselfs since first connection try nearly always fails, while second try basically always succeeds, so extension would be unusable for us without this feature).
* New option "Only warn for found violations": Build-step will result in "succeed-with-issues" instead of "failed" if a vulnerability was detected.
* New PowerShell Core build script (build\Build-Extension.ps1) which will also generate .vsix file, also updated README.md accordingly in build folder
