### PR TITLE
Support multiple paths for parameter scanPath

### DIFF
--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
@@ -72,7 +72,13 @@ async function run() {
         }
 
         // Default args
-        let args = `--project "${projectName}" --scan "${scanPath}" --out "${outField}"`;
+        let args = `--project "${projectName}" --out "${outField}"`;
+
+        // Scan paths
+        let paths = scanPath?.split(',');
+        paths?.forEach(path => {
+            args += ` --scan "${path}"`;
+        });
 
         // Exclude switch
         if (excludePath != sourcesDirectory)


### PR DESCRIPTION
Support multiple paths for parameter `scanPath` to support's the CLI wrapped functionality.

Related issue #104 