### PR TITLE
Match new exitCode on v8 or higher

### DIFF
--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
@@ -196,6 +196,7 @@ async function run() {
         // Process based on exit code
         let failed = exitCode != 0;
         let isViolation = exitCode == (dependencyCheckVersion.match(/^[0-7]\./) ? 1 : 15);
+
         // Process scan artifacts is required
         let processArtifacts = !failed || isViolation;
         if (processArtifacts) {

--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
@@ -195,8 +195,7 @@ async function run() {
 
         // Process based on exit code
         let failed = exitCode != 0;
-        let isViolation = exitCode == 1;
-
+        let isViolation = exitCode == (dependencyCheckVersion.match(/^[0-7]\./) ? 1 : 15);
         // Process scan artifacts is required
         let processArtifacts = !failed || isViolation;
         if (processArtifacts) {


### PR DESCRIPTION
In [`v8.0.0`](https://github.com/jeremylong/DependencyCheck/releases/tag/v8.0.0), the CVSS score failure exit code was changed from 1 to 15 (PR: https://github.com/jeremylong/DependencyCheck/pull/4511), which is why this extension now fails instead of warns on these because it still expects an exit code of 1.

This PR adds support for this by comparing the exitCode with 1 if the input dependency-check version starts with `[0-7].`, and otherwise a 15.