### PR TITLE
Added SARIF to output format options

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -6,7 +6,7 @@ The OWASP Dependency Check Azure DevOps Extension enables the following features
 
 - Software composition analysis runs against package references during build on both Windows and Linux build agents.
 
-- Export vulnerability data to HTML, JSON, XML, CSV, JUnit formatted reports
+- Export vulnerability data to HTML, JSON, XML, CSV, JUnit, SARIF formatted reports
 
 - Download vulnerability reports from the build's artifacts
 

--- a/src/Tasks/dependency-check-build-task/task.json
+++ b/src/Tasks/dependency-check-build-task/task.json
@@ -45,7 +45,7 @@
       "label": "Report Format",
       "defaultValue": "HTML",
       "required": true,
-      "helpMarkDown": "The output format to write to (XML, HTML, CSV, JSON, JUNIT, ALL). Multiple formats can be selected. The default is HTML.",
+      "helpMarkDown": "The output format to write to (XML, HTML, CSV, JSON, JUNIT, SARIF, ALL). Multiple formats can be selected. The default is HTML.",
       "properties": {
         "EditableOptions": "False",
         "MultiSelectFlatList": "True"
@@ -56,6 +56,7 @@
         "CSV": "CSV",
         "JSON": "JSON",
         "JUNIT": "JUNIT",
+        "SARIF": "SARIF",
         "ALL": "ALL"
       }
     },


### PR DESCRIPTION
Adds SARIF to output format options, since OWASP Dependency Check CLI `--format` argument [supports it](http://jeremylong.github.io/DependencyCheck/dependency-check-cli/arguments.html).