### PR TITLE
Allow for custom JAVA_OPTS Environment Variable

### DIFF
--- a/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
+++ b/src/Tasks/dependency-check-build-task/dependency-check-build-task.ts
@@ -158,7 +158,12 @@ async function run() {
         console.log(`Arguments: ${args}`);
 
         // Set Java args
-        tl.setVariable('JAVA_OPTS', '-Xss8192k');
+        const customJavaOpts = tl.getVariable('JAVA_OPTS');
+        if(customJavaOpts) {
+            console.log(`Dependency Check will run with custom JAVA_OPTS: ${customJavaOpts}.`)
+        } else {
+            tl.setVariable('JAVA_OPTS', '-Xss8192k');
+        }
 
         // Version smoke test
         await tl.tool(depCheckPath).arg('--version').exec();


### PR DESCRIPTION
Before this change `tl.setVariable` would override any custom `JAVA_OPTS`, making it impossible to set Java memory as needed in #144

Will print if any non-default `JAVA_OPTS` are set, for better debugging, if nothing is defined it will use the default `'-Xss8192k'` as said before, so this is not a breaking change.

Fixes #131