### PR TITLE
Fix issue with `workspaceRepo: true` in Azure Pipelines  

### DIFF
--- a/Tasks/DependencyCheck/dependency-check-build-task.ts
+++ b/Tasks/DependencyCheck/dependency-check-build-task.ts
@@ -137,6 +137,8 @@ async function run() {
 
             cleanLocalInstallPath(localInstallPath);
             await unzipFromUrl(zipUrl, localInstallPath);
+
+            localInstallPath = path.join(localInstallPath, 'dependency-check');
         }
 
         // Pull cached data archive

--- a/Tasks/DependencyCheck/dependency-check-build-task.ts
+++ b/Tasks/DependencyCheck/dependency-check-build-task.ts
@@ -124,8 +124,6 @@ async function run() {
         // Set installation location
         if (localInstallPath == sourcesDirectory) {
             hasLocalInstallation = false;
-            localInstallPath = path.join(__dirname, 'dependency-check');
-
             tl.checkPath(localInstallPath, 'Dependency Check installer');
 
             let zipUrl: string;

--- a/Tasks/DependencyCheck/dependency-check-build-task.ts
+++ b/Tasks/DependencyCheck/dependency-check-build-task.ts
@@ -51,7 +51,7 @@ async function run() {
         if (localInstallPath !== undefined) localInstallPath = localInstallPath.trim();
         if (nvdApiKey !== undefined) nvdApiKey = nvdApiKey.trim();
 
-        const sourcesDirectory = tl.getVariable('Build.SourcesDirectory');
+        const sourcesDirectory = tl.getVariable('Build.Repository.LocalPath');
         const testDirectory = tl.getVariable('Common.TestResultsDirectory');
 
         // Set reports directory (if necessary)
@@ -138,7 +138,7 @@ async function run() {
             }
 
             cleanLocalInstallPath(localInstallPath);
-            await unzipFromUrl(zipUrl, path.join(localInstallPath, '../'));
+            await unzipFromUrl(zipUrl, localInstallPath);
         }
 
         // Pull cached data archive


### PR DESCRIPTION
## Description  
This PR resolves an issue occurring when using  

```yaml
- checkout: self
  workspaceRepo: true
```

The problem was caused by the use of `Build.SourcesDirectory`, which does not work correctly in a multi-repo setup with `workspaceRepo: true`.  

## Changes made  
- **Replaced** `Build.SourcesDirectory` with `Build.Repository.LocalPath` to correctly reference the repository path.  
- **Removed** `__dirname` usage, as with `workspaceRepo: true`, the current directory is already the repository root, whereas `Build.SourcesDirectory` in a multi-repo setup points one level above.  

This fix ensures proper handling of paths when using multi-repo checkouts in Azure Pipelines.