### PR TITLE
Updated Repository Links

### DIFF
--- a/Tasks/DependencyCheck/dependency-check-build-task.ts
+++ b/Tasks/DependencyCheck/dependency-check-build-task.ts
@@ -6,7 +6,7 @@ import decompress from 'decompress';
 import { IHttpClientResponse } from 'typed-rest-client/Interfaces';
 
 const client = new httpClient.HttpClient('DC_AGENT');
-const releaseApi = 'https://api.github.com/repos/jeremylong/DependencyCheck/releases';
+const releaseApi = 'https://api.github.com/repos/dependency-check/DependencyCheck/releases';
 
 async function run() {
     console.log("Starting Dependency Check...")

--- a/overview.md
+++ b/overview.md
@@ -30,7 +30,7 @@ The extension maintainers do not monitor the Marketplace Question & Answers. Ple
 
     <img src="https://raw.githubusercontent.com/dependency-check/azuredevops/main/screenshots/buildtask-add.png">
 
-- Configure the build task with the appropriate [Dependency Check Command Line Arguments](https://jeremylong.github.io/DependencyCheck/dependency-check-cli/arguments.html).
+- Configure the build task with the appropriate [Dependency Check Command Line Arguments](https://dependency-check.github.io/DependencyCheck/dependency-check-cli/arguments.html).
 
     <img src="https://raw.githubusercontent.com/dependency-check/azuredevops/main/screenshots/buildtask-configure.png">
 
@@ -66,7 +66,7 @@ The extension maintainers do not monitor the Marketplace Question & Answers. Ple
 
 ## Learn More
 
-More details on configuring and running Dependency Check can be found at [https://jeremylong.github.io/DependencyCheck/](https://jeremylong.github.io/DependencyCheck/).
+More details on configuring and running Dependency Check can be found at [https://dependency-check.github.io/DependencyCheck/](https://dependency-check.github.io/DependencyCheck/).
 
 ## Supported Environments
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -71,10 +71,10 @@
       "uri": "https://github.com/dependency-check/azuredevops/issues"
     },
     "getstarted": {
-      "uri": "https://jeremylong.github.io/DependencyCheck/index.html"
+      "uri": "https://dependency-check.github.io/DependencyCheck/index.html"
     },
     "support": {
-      "uri": "https://github.com/jeremylong/DependencyCheck"
+      "uri": "https://github.com/dependency-check/DependencyCheck"
     }
   },
   "branding": {


### PR DESCRIPTION
The location of Dependency Check project has migrated as per https://github.com/jeremylong/DependencyCheck/issues/7412

I've updated the releaseApi location, overview markdown, and vss-extension files to reflect this.

resolves: https://github.com/dependency-check/azuredevops/issues/172
resolves: https://github.com/dependency-check/azuredevops/issues/174