### PR TITLE
Fix node 20 configuration

### DIFF
--- a/Tasks/DependencyCheck/task.json
+++ b/Tasks/DependencyCheck/task.json
@@ -199,7 +199,7 @@
       "target": "dependency-check-build-task.js",
       "argumentFormat": ""
     },
-    "Node20": {
+    "Node20_1": {
       "target": "dependency-check-build-task.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
While running "dependency-check-build-task@6" task on an Azure DevOps pipeline this warning is shown:

`##[warning]Task 'OWASP Dependency Check' version 6 (dependency-check-build-task@6) is dependent on a Node version (16) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance`

<img width="1172" height="127" alt="image" src="https://github.com/user-attachments/assets/471634be-b35a-4006-89cc-fe17345c705c" />

I noticed that the task is configured to run on Node 10, Node 16, and Node 20, but Node 20 is not working. After doing some research, I found that the reason it still uses Node 16 is that the handler name in `task.json` is incorrect for Node 20. Azure Pipelines expects `Node20_1`, not `Node20`.


